### PR TITLE
Fixes issue with StopIteration exceptions using python 3.7

### DIFF
--- a/onir/util/concurrency.py
+++ b/onir/util/concurrency.py
@@ -50,7 +50,10 @@ def _blocking_tee_iter(ctrl, ev_available):
         ev_available.wait()
         ev_available.clear()
         if ctrl.ex:
-            raise ctrl.ex
+            if isinstance(ctrl.ex, StopIteration):
+                break
+            else:
+                raise ctrl.ex
         value = ctrl.value
         ctrl.notify_grabbed()
         if value is not StopIteration:

--- a/onir/util/concurrency.py
+++ b/onir/util/concurrency.py
@@ -56,8 +56,7 @@ def _blocking_tee_iter(ctrl, ev_available):
                 raise ctrl.ex
         value = ctrl.value
         ctrl.notify_grabbed()
-        if value is not StopIteration:
-            yield value
+        yield value
 
 
 class _BlockingTeeControllerThread(Thread):


### PR DESCRIPTION
Python 3.7 changes how StopIteration exceptions internal to a generator are handled. Before they were silently swallowed and now they are converted to runtime exceptions. This causes issues with blocking tee code in OpenNIR. BlockingTeeControllerThread's run method catches the StopIteration and and stores it. _blocking_tee_iter() access that exception and re-raises it. This worked in earlier Python versions, but the preferred manner to handle this is to catch internal StopIterations and terminate the generator.

I added a test for exception type so that a file not found exception or similar would still bubble up the stack.

I'll also mention that this code isn't doing what is expected:
```
        if value is not StopIteration:
            yield value
```
The function next() raises a StopIteration exception so ctrl.value is not updated. (The older style iter.next() would return a StopIteration I believe). If there was a reason to test for StopIteration, it should be done with isinstance. It is not hurting anything because the `is not` test is always true, but should probably be changed to simple yield the value without the test. I can do that on this PR if desired.