### PR TITLE
optional gensim; 3.11 support

### DIFF
--- a/onir/interfaces/wordvec.py
+++ b/onir/interfaces/wordvec.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 import zipfile
 import numpy as np
-from gensim.models.keyedvectors import KeyedVectors
 from onir import util
 from onir.interfaces import plaintext
 
@@ -104,6 +103,10 @@ def convknrm_handler(base_url):
 
 
 def gensim_w2v_handler(url):
+    try:
+        from gensim.models.keyedvectors import KeyedVectors
+    except E:
+        raise "gensim needs to be installed for this to work" from E
     def wrapped(logger):
         with tempfile.TemporaryDirectory() as p:
             vocab_path = os.path.join(p, 'vocab')

--- a/onir/interfaces/wordvec.py
+++ b/onir/interfaces/wordvec.py
@@ -105,8 +105,8 @@ def convknrm_handler(base_url):
 def gensim_w2v_handler(url):
     try:
         from gensim.models.keyedvectors import KeyedVectors
-    except E:
-        raise "gensim needs to be installed for this to work" from E
+    except ImportError as ie:
+        raise "gensim needs to be installed for this to work" from ie
     def wrapped(logger):
         with tempfile.TemporaryDirectory() as p:
             vocab_path = os.path.join(p, 'vocab')

--- a/onir/interfaces/wordvec.py
+++ b/onir/interfaces/wordvec.py
@@ -103,16 +103,17 @@ def convknrm_handler(base_url):
 
 
 def gensim_w2v_handler(url):
-    try:
-        from gensim.models.keyedvectors import KeyedVectors
-    except ImportError as ie:
-        raise "gensim needs to be installed for this to work" from ie
     def wrapped(logger):
         with tempfile.TemporaryDirectory() as p:
             vocab_path = os.path.join(p, 'vocab')
             with logger.duration(f'downloading {url}'):
                 util.download(url, vocab_path)
             with logger.duration(f'loading binary {vocab_path}'):
+                try:
+                    from gensim.models.keyedvectors import KeyedVectors
+                except ModuleNotFoundError as mnfe:
+                    print("gensim needs to be installed for gensim_w2v_handler to work") 
+                    raise mnfe
                 vectors = KeyedVectors.load_word2vec_format(vocab_path, binary=True)
             vocab_path += '.txt'
             with logger.duration(f'saving text {vocab_path}'):

--- a/onir_pt/__init__.py
+++ b/onir_pt/__init__.py
@@ -522,6 +522,8 @@ class OpenNIRPyterrierReRanker(pyterrier.transformer.EstimatorBase):
 
 
 def _inject(cls, context={}):
+    if not hasattr(inspect, 'getargspec'):
+        inspect.getargspec = inspect.getfullargspec
     spec = inspect.getargspec(cls.__init__)
     args = []
     for arg in spec.args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ nltk>=3.4.5
 git+https://github.com/TREMA-UNH/trec-car-tools.git#subdirectory=python3
 sqlitedict>=1.6.0
 pytrec-eval-terrier>=0.5.1
-gensim>=3.7.3
 Cython>=0.29.2
 pyjnius>=1.2.1
 ir_datasets>=0.2.0
@@ -34,3 +33,6 @@ ir_measures>=0.2.1
 # misc
 pytools>=2018.5.2
 cached-property>=1.5.1
+
+# optional:
+# gensim>=3.7.3


### PR DESCRIPTION
- gensim requires numpy < 2. Colab has moved onto numpy 2. So make gensim support optional
- inspect.getargspec has gone. so use a workaround